### PR TITLE
.NET Core 3.1+ Compatibility

### DIFF
--- a/AuthorizeNET/AuthorizeNET/AuthorizeNET.csproj
+++ b/AuthorizeNET/AuthorizeNET/AuthorizeNET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
 
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>

--- a/AuthorizeNET/AuthorizeNET/Utilities/LogFactory.cs
+++ b/AuthorizeNET/AuthorizeNET/Utilities/LogFactory.cs
@@ -5,11 +5,10 @@
 
     public static class LogFactory
     {
-        private static ILoggerFactory LoggerFactory => new LoggerFactory().AddDebug(LogLevel.Debug);
-
         public static ILogger getLog(Type classType)
         {
-            return LoggerFactory.CreateLogger(classType.FullName);
+            using var loggerFactory = LoggerFactory.Create(builder => builder.AddDebug());
+            return loggerFactory.CreateLogger(classType.FullName);
         }
     }
 }


### PR DESCRIPTION
This fork includes the minimal changes needed for this SDK to support versions of .NET Core 3.1+. 

Migrated deprecated ILoggerFactory method to version supported in .NET Core 3.1+.
Changed target framework to .NET Core 3.1.
Updated packages to current versions.